### PR TITLE
Opens a new tab instead of redirecting the page

### DIFF
--- a/_includes/bootstrap-header.html
+++ b/_includes/bootstrap-header.html
@@ -52,7 +52,7 @@
         <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 <li><a
-                        href="https://github.com/developerforce/lightning-process-builder-tutorial/tree/gh-pages"><img
+                        href="https://github.com/developerforce/lightning-process-builder-tutorial/tree/gh-pages" target="_blank"><img
                         src="images/icon-github.png" style="border: none;margin: -4px 0;height: 28px;width: 28px;"/>
                     GitHub
                     Project</a></li>


### PR DESCRIPTION
When you click on the logo, it opens the URL in a new tab instead of redirecting from the current page